### PR TITLE
Remove content_type argument choices

### DIFF
--- a/httprequest_blueprints/execute_request.py
+++ b/httprequest_blueprints/execute_request.py
@@ -16,12 +16,7 @@ def get_args():
         '--content-type',
         dest='content_type',
         required=False,
-        default=None,
-        choices={
-            'text/plain',
-            'application/xml',
-            'application/json',
-            'text/html'})
+        default=None)
     parser.add_argument('--message', dest='message', required=False)
     parser.add_argument(
         '--print-response',


### PR DESCRIPTION
There's no need to limit these. Removing this gives us the ability to continuously add more in the Shipyard UI without restriction.